### PR TITLE
Add u2204 test, simplify role aka basedeps

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Ansible & Molecule
         run: |
             pip install "ansible<8" "ansible-lint<6.13" flake8
@@ -46,7 +46,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: galaxy
         uses: robertdebock/galaxy-action@1.2.1

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install Redis
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.10
   platforms:
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,9 @@ galaxy_info:
     - name: EL
       versions:
         - 9
+    - name: Ubuntu
+      versions:
+        - jammy
   namespace: ome
   role_name: redis
   galaxy_tags: []

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,17 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: instance
+  - name: rockylinux-9
     image: eniocarboni/docker-rockylinux-systemd:9
+    command: /sbin/init
+    privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
+    groups:
+      - extra_options
+  - name: ubuntu-2204
+    image: eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
     cgroupns_mode: host

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     state: present
   when: ansible_os_family == 'RedHat'
 
-- name: install redis
+- name: Install redis
   become: true
   ansible.builtin.apt:
     update_cache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
   when: ansible_os_family == 'RedHat'
 
-- name: epel | setup dnf repository
+- name: Setup dnf repository, epel
   become: true
   ansible.builtin.dnf:
     update_cache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,40 +1,35 @@
 ---
 # tasks file for roles/redis
 
-- name : check rocky.repo file
-  stat:
-    path: /etc/yum.repos.d/rocky.repo
-  register: rockyrepo_name
+- name: Import a key for epel
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+  when: ansible_os_family == 'RedHat'
 
-- name: system packages | Add CRB repository for RHEL
-  become: true
-  ansible.builtin.command:
-    subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
-  when: ansible_os_family == 'RedHat' and not rockyrepo_name.stat.exists
-
-- name: system packages | install epel repo
+- name: epel | setup dnf repository
   become: true
   ansible.builtin.dnf:
-    name: epel-release
+    update_cache: true
+    name:
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     state: present
-  when: rockyrepo_name.stat.exists
+  when: ansible_os_family == 'RedHat'
 
 - name: install redis
   become: true
   ansible.builtin.dnf:
     name: redis
     state: present
+  when: ansible_os_family == 'RedHat'
 
-- name: configure redis
+- name: install redis
   become: true
-  lineinfile:
-    dest: /etc/redis/redis.conf
-    line: "bind {{ redis_listen | default('127.0.0.1') }}"
-    regexp: "^bind\\s.*"
+  ansible.builtin.apt:
+    update_cache: true
+    name: redis
     state: present
-  notify:
-    - restart redis
-  when: rockyrepo_name.stat.exists
+  when: ansible_os_family == 'Debian'
 
 # Note: Fails in --check mode with /etc/redis/redis.conf
 # does not exist
@@ -47,7 +42,6 @@
     state: present
   notify:
     - restart redis
-  when: ansible_os_family == 'RedHat' and not rockyrepo_name.stat.exists
 
 - name: set redis to start on startup
   become: true


### PR DESCRIPTION
This role would not work on Ubuntu 22.04. 
Also, the logic here was redundant - 2 blocks with repeating code.

This PR:

1. Adds test for Ubuntu 22.04
2. Cleans up the logic with epel repo install in line with https://github.com/ome/ansible-role-basedeps/blob/master/tasks/main.yml
3. python is bumped to 3.9
4. v4 versions of the actions is used, all testing framework runs on ubuntu22.04
5. minimal ansible version is highlighted in meta/main.yml as ``2.10``

